### PR TITLE
Send per-player state updates to targeted sockets

### DIFF
--- a/zombie_http_v8_0/static/app.js
+++ b/zombie_http_v8_0/static/app.js
@@ -286,8 +286,9 @@ socket.on('chat', (m)=>{
   box.innerHTML += `<div class="${sys}"><b>${m.user}:</b> ${m.text}</div>`;
   box.scrollTop=box.scrollHeight;
 });
-socket.on('state_update', (payload)=>{
+socket.on('state_update', (payload={})=>{
   if(!ROOM_ID || payload.room_id!==ROOM_ID) return;
+  if(payload.target && payload.target!==USER) return;
   const st=payload.state; GAME_STATE=st;
   SUN_NOW=st.sun;
   ZOMBIE_POINTS=st.zombie_points||ZOMBIE_POINTS;


### PR DESCRIPTION
## Summary
- emit state updates to user-specific Socket.IO rooms and include the recipient in the payload
- join and leave players' personal rooms during room join/rejoin/leave events
- ignore state_update packets on the client when the payload target does not match the current user

## Testing
- python3 -m py_compile zombie_http_v8_0/app.py

------
https://chatgpt.com/codex/tasks/task_e_68dfb20e79fc832ab3e93b629de0ce13