### PR TITLE
Default coop snapshots to defender role

### DIFF
--- a/zombie_http_v8_0/app.py
+++ b/zombie_http_v8_0/app.py
@@ -544,7 +544,7 @@ def snapshot(room, me):
     if not st: return None
     small_grid=[[None if not cell else {"type":cell["type"],"hp":int(cell["hp"])} for cell in row] for row in st["grid"]]
     mode = st.get("mode") or room.get("mode")
-    role = "observer"
+    role = "defender" if mode != "pvp" else "observer"
     if st.get("defender") == me:
         role = "defender"
     elif st.get("attacker") == me:


### PR DESCRIPTION
## Summary
- default snapshot roles to defender for non-PvP players so coop participants are no longer treated as observers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfb5eb0ad8832ab358d7957ce4da7a