### PR TITLE
Initialize PvP weather state to prevent missing key errors

### DIFF
--- a/zombie_http_v8_0/app.py
+++ b/zombie_http_v8_0/app.py
@@ -243,6 +243,7 @@ def init_game_state(room):
             "wave_done":[False, False],
             "await_next":False,
             "waves":[],
+            "weather": "clear",
             "owned_plants": owned_cache,
         }
         return
@@ -412,7 +413,7 @@ def step_game(room,dt):
             if not plant: continue
             ptype = plant["type"]; owner = plant.get("owner")
             if ptype=="sunflower":
-                rain_boost = 0.7 if st["weather"]=="rain" else 1.0
+                rain_boost = 0.7 if st.get("weather","clear")=="rain" else 1.0
                 key=f"{r},{c}"; last=st["sunflower_timers"].get(key,0.0)
                 # stop sunflower if half finished and awaiting
                 half = 0 if r<=2 else 1
@@ -426,7 +427,7 @@ def step_game(room,dt):
                 if plant["cd"]<=0:
                     px=c*CELL_SIZE+40
                     # fog reduces visibility
-                    sight = FIELD_WIDTH if st["weather"]!="fog" else 220
+                    sight = FIELD_WIDTH if st.get("weather","clear")!="fog" else 220
                     visible = any((z["row"]==r and z["x"]>px and (z["x"]-px)<=sight) for z in st["zombies"])
                     if visible:
                         if ptype=="peashooter":


### PR DESCRIPTION
## Summary
- ensure the PvP game state starts with a weather entry so plants can spawn without errors
- guard weather-dependent logic with safe defaults to avoid crashes when weather is absent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfcb34aab0832abb6231ce6d8a48d3