### PR TITLE
Increase zombie wave cooldown to 30 seconds

### DIFF
--- a/zombie_http_v8_0/app.py
+++ b/zombie_http_v8_0/app.py
@@ -68,7 +68,7 @@ ZOMBIE_CLASS_ICONS = {
 
 ZOMBIE_POINT_RATE = 6.0
 ZOMBIE_WAVE_BONUS = 30
-ZOMBIE_WAVE_COOLDOWN = 15.0
+ZOMBIE_WAVE_COOLDOWN = 30.0
 
 # ---- Storage helpers ----
 def load_json(path, default):


### PR DESCRIPTION
## Summary
- raise the zombie wave cooldown constant to 30 seconds so waves take longer to recharge

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfd294d698832aa1e4270e036da896