### PR TITLE
Adjust plant durability to new balance

### DIFF
--- a/zombie_http_v8_0/app.py
+++ b/zombie_http_v8_0/app.py
@@ -23,8 +23,8 @@ SUNFLOWER_PERIOD = 5.0
 
 PLANT_COSTS = {"sunflower":50,"peashooter":100,"wallnut":50,"freeze":150,"bomb":200,
                "icepea":140,"potato":25,"spikeweed":70,"tallnut":125,"cabbage":160}
-PLANT_HP = {"sunflower":120,"peashooter":120,"wallnut":600,"freeze":160,"bomb":100,
-            "icepea":120,"potato":60,"spikeweed":180,"tallnut":1500,"cabbage":120}
+PLANT_HP = {"sunflower":90,"peashooter":100,"wallnut":450,"freeze":130,"bomb":95,
+            "icepea":100,"potato":55,"spikeweed":140,"tallnut":1100,"cabbage":100}
 PEA_DAMAGE = 20
 BULLET_SPEED = 150  # slower projectiles
 
@@ -581,7 +581,9 @@ def step_game(room,dt):
 def snapshot(room, me):
     st = room.get("game")
     if not st: return None
-    small_grid=[[None if not cell else {"type":cell["type"],"hp":int(cell["hp"])} for cell in row] for row in st["grid"]]
+    small_grid=[[None if not cell else {"type":cell["type"],"hp":int(cell["hp"]),
+                                         "hp_max":int(PLANT_HP.get(cell["type"], cell["hp"]))}
+                 for cell in row] for row in st["grid"]]
     mode = st.get("mode") or room.get("mode")
     role = "defender" if mode != "pvp" else "observer"
     if st.get("defender") == me:

--- a/zombie_http_v8_0/static/app.js
+++ b/zombie_http_v8_0/static/app.js
@@ -19,6 +19,19 @@ const DEFAULT_OWNED = ['peashooter','sunflower','wallnut'];
 const DEFAULT_ZOMBIE_CLASSES = ['normal','cone','bucket'];
 const DEFAULT_ZOMBIE_DECK = DEFAULT_ZOMBIE_CLASSES.slice();
 
+const PLANT_HP_HINT={
+  sunflower:90,
+  peashooter:100,
+  wallnut:450,
+  freeze:130,
+  bomb:95,
+  icepea:100,
+  potato:55,
+  spikeweed:140,
+  tallnut:1100,
+  cabbage:100,
+};
+
 const PLANTS_ALL=[
   {key:'1', code:'peashooter', name:'Стрелок', icon:'🌱', cost:100},
   {key:'2', code:'sunflower',  name:'Подсолнух', icon:'🌻', cost:50},
@@ -782,7 +795,8 @@ function redrawDefender(){
       const x=c*80+8,y=r*80+8,w=80-16;
       const colors={sunflower:'#ffd700',peashooter:'#4ade80',wallnut:'#b08968',freeze:'#7dd3fc',bomb:'#ef4444', icepea:'#60a5fa', potato:'#a8a29e', spikeweed:'#16a34a', tallnut:'#92400e', cabbage:'#84cc16'};
       ctx.fillStyle=colors[cell.type]||'#000'; ctx.fillRect(x,y,w,w);
-      ctx.fillStyle='#065f46'; const maxhp=(cell.type==='tallnut'?1500:(cell.type==='wallnut'?600:300)); const hpw=Math.max(0,Math.min(1,cell.hp/maxhp))*w; ctx.fillRect(x,y-6,hpw,5);
+      const maxhp = cell.hp_max || PLANT_HP_HINT[cell.type] || 1;
+      ctx.fillStyle='#065f46'; const hpw=Math.max(0,Math.min(1,cell.hp/maxhp))*w; ctx.fillRect(x,y-6,hpw,5);
     }
   }
   ctx.fillStyle='#111'; st.bullets.forEach(b=>{ ctx.beginPath(); ctx.arc(b.x, b.row*80+40, 5, 0, Math.PI*2); ctx.fill(); });
@@ -833,7 +847,8 @@ function redrawZombie(){
       const x=c*80+8,y=r*80+8,w=80-16;
       const colors={sunflower:'#ffd700',peashooter:'#4ade80',wallnut:'#b08968',freeze:'#7dd3fc',bomb:'#ef4444', icepea:'#60a5fa', potato:'#a8a29e', spikeweed:'#16a34a', tallnut:'#92400e', cabbage:'#84cc16'};
       ctx.fillStyle=colors[cell.type]||'#000'; ctx.fillRect(x,y,w,w);
-      ctx.fillStyle='#065f46'; const maxhp=(cell.type==='tallnut'?1500:(cell.type==='wallnut'?600:300)); const hpw=Math.max(0,Math.min(1,cell.hp/maxhp))*w; ctx.fillRect(x,y-6,hpw,5);
+      const maxhp = cell.hp_max || PLANT_HP_HINT[cell.type] || 1;
+      ctx.fillStyle='#065f46'; const hpw=Math.max(0,Math.min(1,cell.hp/maxhp))*w; ctx.fillRect(x,y-6,hpw,5);
     }
   }
   ctx.fillStyle='#111'; st.bullets.forEach(b=>{ ctx.beginPath(); ctx.arc(b.x, b.row*80+40, 5, 0, Math.PI*2); ctx.fill(); });


### PR DESCRIPTION
## Summary
- lower all plant HP values to the new balance and expose hp_max to the client snapshot
- update the frontend to use the new plant HP values for health bars with server-provided fallbacks

## Testing
- python -m compileall app.py static/app.js

------
https://chatgpt.com/codex/tasks/task_e_68dfe73be778832a929ee19336699de0