### PR TITLE
Improve shop modal scrolling

### DIFF
--- a/zombie_http_v8_0/static/app.js
+++ b/zombie_http_v8_0/static/app.js
@@ -200,7 +200,7 @@ function renderShop(){
       ${extra}
     </div><div style="text-align:right">${status}</div></div>`;
   }).join('') : '<div class="muted">Нет доступных предметов</div>';
-  box.innerHTML = `<div><b>Ваши монеты:</b> ${coins}</div><div class="sep"></div>${tabsHtml}<div class="sep"></div>${cardsHtml}`;
+  box.innerHTML = `<div><b>Ваши монеты:</b> ${coins}</div><div class="sep"></div>${tabsHtml}<div class="sep"></div><div class="shop-items">${cardsHtml}</div>`;
 }
 
 function setShopTab(tab){

--- a/zombie_http_v8_0/static/index.html
+++ b/zombie_http_v8_0/static/index.html
@@ -40,7 +40,9 @@
   .icon{width:28px;height:28px;display:inline-flex;align-items:center;justify-content:center;font-size:18px}
   .badge{font-size:12px;padding:2px 6px;border-radius:8px;border:1px solid var(--border);background:#fff}
   .modal{position:fixed;inset:0;background:rgba(0,0,0,.35);display:none;align-items:center;justify-content:center;padding:16px}
-  .modal > .box{background:#fff;border-radius:14px;min-width:320px;max-width:520px;padding:16px;border:1px solid var(--border)}
+  .modal > .box{background:#fff;border-radius:14px;min-width:320px;max-width:520px;max-height:90vh;padding:16px;border:1px solid var(--border);overflow-y:auto}
+  #shopBox{display:flex;flex-direction:column;gap:8px}
+  .shop-items{max-height:60vh;overflow-y:auto;padding-right:4px}
   .avatar{width:28px;height:28px;border-radius:999px;vertical-align:middle;margin-right:8px}
 </style>
 </head>


### PR DESCRIPTION
## Summary
- add a height limit and vertical scrolling to modal boxes with a dedicated shop list container
- wrap rendered shop items in the new scrollable block so the header and tabs stay visible

## Testing
- python - <<'PY' (Playwright script to open the app, switch shop tabs, and scroll the shop list)


------
https://chatgpt.com/codex/tasks/task_e_68dfea8b46b0832a8b3da0295890dcfb