### PR TITLE
Block planting when zombies occupy a tile

### DIFF
--- a/zombie_http_v8_0/static/app.js
+++ b/zombie_http_v8_0/static/app.js
@@ -910,6 +910,18 @@ function redrawZombie(){
 function canPlace(r,c){
   if(!GAME_STATE) return false;
   if(GAME_STATE.grid[r][c]) return false;
+  const cellRight=(c+1)*80;
+  const threshold=cellRight - 0.4*80;
+  if(Array.isArray(GAME_STATE.zombies)){
+    for(const z of GAME_STATE.zombies){
+      if(!z || z.row!==r) continue;
+      const zx=Number(z.x);
+      if(!Number.isFinite(zx)) continue;
+      if(Math.floor(zx/80)!==c) continue;
+      if(z.flying) continue;
+      if(zx < threshold) return false;
+    }
+  }
   if((ROOM_CACHE?.mode)==='pvp'){ return MY_ROLE!=='attacker'; }
   const allowed = (MY_INDEX===0) ? (r>=0 && r<3) : (r>=3 && r<6);
   return allowed;


### PR DESCRIPTION
## Summary
- prevent defenders from planting in tiles where a zombie has advanced more than 40% into the cell server-side
- include flying state in zombie snapshots and mirror the placement restriction in the client UI

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfee890e8c832aa6bbcb67319991a4