### PR TITLE
Allow selling plants by clicking on them

### DIFF
--- a/zombie_http_v8_0/static/app.js
+++ b/zombie_http_v8_0/static/app.js
@@ -611,8 +611,7 @@ function renderDefenderGame(isPvP){
     const rect=cvs.getBoundingClientRect(); const x=e.clientX-rect.left, y=e.clientY-rect.top;
     if(x>9*80) return; const c=Math.floor(x/80), r=Math.floor(y/80);
     const cellData=(GAME_STATE?.grid?.[r]||[])[c];
-    if(e.shiftKey){
-      if(!cellData){ setStatus('Здесь нет растения для продажи'); return; }
+    if(cellData){
       const plantType=cellData?.type;
       if(!plantType){ setStatus('Нельзя продать неизвестное растение'); return; }
       PENDING_ACTIONS.push({type:'sell', row:r, col:c, ptype:plantType});


### PR DESCRIPTION
## Summary
- allow defenders to sell a planted unit by simply clicking on the occupied tile
- keep planting flow for empty cells unchanged while emitting the sell event when a plant is present

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e29ae20eec832a8b4be426fb146111