### PR TITLE
Add username availability check API and UI feedback

### DIFF
--- a/zombie_http_v8_0/app.py
+++ b/zombie_http_v8_0/app.py
@@ -764,6 +764,17 @@ def api_register():
     save_users(users)
     return jsonify({"status":"ok"})
 
+@app.route("/api/check_username")
+def api_check_username():
+    name=(request.args.get("username") or "").strip()
+    err=validate_username(name)
+    if err:
+        return jsonify({"available": False, "msg": err})
+    users=load_users()
+    if name in users:
+        return jsonify({"available": False, "msg": "Пользователь уже существует"})
+    return jsonify({"available": True, "msg": "Логин свободен"})
+
 @app.route("/api/login", methods=["POST"])
 def api_login():
     data=request.json or {}


### PR DESCRIPTION
## Summary
- add an /api/check_username endpoint that validates login names and reports availability
- show debounced username availability status on the auth screen and disable registration on invalid names

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e2a02d0604832ab2e199feb34ed9ad