### PR TITLE
Improve profile modal inventory rendering

### DIFF
--- a/zombie_http_v8_0/static/index.html
+++ b/zombie_http_v8_0/static/index.html
@@ -39,6 +39,10 @@
   .card.selected{outline:2px solid var(--accent)}
   .icon{width:28px;height:28px;display:inline-flex;align-items:center;justify-content:center;font-size:18px}
   .badge{font-size:12px;padding:2px 6px;border-radius:8px;border:1px solid var(--border);background:#fff}
+  .inventory-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:8px}
+  .inventory-grid .card{cursor:default;padding:12px 14px;user-select:auto;transition:none;align-items:flex-start}
+  .profile-tabs{display:inline-flex;gap:6px}
+  .profile-tabs .btn{margin:0}
   .modal{position:fixed;inset:0;background:rgba(0,0,0,.35);display:none;align-items:center;justify-content:center;padding:16px}
   .modal > .box{background:#fff;border-radius:14px;min-width:320px;max-width:520px;max-height:90vh;padding:16px;border:1px solid var(--border);overflow-y:auto}
   #shopBox{display:flex;flex-direction:column;gap:8px}


### PR DESCRIPTION
## Summary
- add cached profile view state and render helpers for the profile modal inventory tabs
- refresh the open profile modal when profile data changes from store calls or socket syncs
- add styles for the profile inventory grid and tab buttons

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68e29efbf438832a870e315df548ceb4