### PR TITLE
Add password strength indicator to auth screen

### DIFF
--- a/zombie_http_v8_0/static/app.js
+++ b/zombie_http_v8_0/static/app.js
@@ -471,6 +471,41 @@ function updateAuthStatusUI(){
   }
 }
 
+function evaluatePasswordStrength(password=''){
+  const value=String(password||'');
+  if(!value){
+    return {score:0,label:'Введите пароль'};
+  }
+  let score=0;
+  if(value.length>=4) score++;
+  if(value.length>=8) score++;
+  if(/[a-z]/.test(value) && /[A-Z]/.test(value)) score++;
+  if(/\d/.test(value)) score++;
+  if(/[^A-Za-z0-9]/.test(value)) score++;
+  score=Math.min(score,4);
+  const labels=['Очень слабый','Слабый','Средний','Хороший','Сильный'];
+  return {score,label:labels[score]};
+}
+
+function updatePasswordStrengthUI(password=''){
+  const indicator=document.getElementById('passStrength');
+  if(!indicator) return;
+  const {score,label}=evaluatePasswordStrength(password);
+  const classes=['level-0','level-1','level-2','level-3','level-4'];
+  indicator.classList.toggle('is-empty', !password);
+  classes.forEach(cls=>indicator.classList.remove(cls));
+  indicator.classList.add(classes[score]||'level-0');
+  const bar=indicator.querySelector('.pass-strength__bar');
+  const text=indicator.querySelector('.pass-strength__label');
+  if(bar){
+    const percent=score===0 && !password ? 0 : (score/4)*100;
+    bar.style.width = `${percent}%`;
+  }
+  if(text){
+    text.textContent = password ? label : 'Введите пароль';
+  }
+}
+
 function initAuthControls(){
   USERNAME_CHECK_STATE={available:false,msg:'Введите логин',tone:'muted',pending:false};
   updateAuthStatusUI();
@@ -478,6 +513,12 @@ function initAuthControls(){
   if(!loginInput) return;
   loginInput.addEventListener('input', ()=>scheduleUsernameCheck(loginInput.value));
   scheduleUsernameCheck(loginInput.value);
+  const passInput=document.getElementById('pass');
+  if(passInput){
+    const handler=()=>updatePasswordStrengthUI(passInput.value);
+    passInput.addEventListener('input', handler);
+    updatePasswordStrengthUI(passInput.value);
+  }
 }
 
 function renderAuth(){
@@ -485,6 +526,10 @@ function renderAuth(){
   <div class="row"><input id="login" placeholder="Логин (латиница/цифры ._-)" /></div>
   <div class="muted" id="loginStatus"></div>
   <div class="row"><input id="pass" type="password" placeholder="Пароль (мин. 4 символа)" /></div>
+  <div id="passStrength" class="pass-strength level-0 is-empty">
+    <div class="pass-strength__track"><div class="pass-strength__bar"></div></div>
+    <div class="pass-strength__label muted">Введите пароль</div>
+  </div>
   <div class="row"><button id="registerBtn" class="btn" onclick="register()"><span>📝</span> Регистрация</button>
   <button class="btn primary" onclick="signin()"><span>🔑</span> Вход</button></div>
   <div class="muted" id="authMsg"></div>`;

--- a/zombie_http_v8_0/static/index.html
+++ b/zombie_http_v8_0/static/index.html
@@ -44,6 +44,17 @@
   #shopBox{display:flex;flex-direction:column;gap:8px}
   .shop-items{max-height:60vh;overflow-y:auto;padding-right:4px}
   .avatar{width:28px;height:28px;border-radius:999px;vertical-align:middle;margin-right:8px}
+  .pass-strength{margin:6px 0 12px;transition:all .25s ease}
+  .pass-strength__track{width:100%;height:8px;border-radius:999px;background:var(--border);overflow:hidden}
+  .pass-strength__bar{height:100%;width:0%;background:var(--bad);transition:width .25s ease,background .25s ease}
+  .pass-strength__label{margin-top:4px;font-size:12px;color:var(--muted);transition:color .25s ease}
+  .pass-strength.is-empty .pass-strength__bar{width:0%}
+  .pass-strength.level-1 .pass-strength__bar{background:#f97316}
+  .pass-strength.level-2 .pass-strength__bar{background:#facc15}
+  .pass-strength.level-3 .pass-strength__bar{background:var(--accent)}
+  .pass-strength.level-4 .pass-strength__bar{background:var(--good)}
+  .pass-strength.level-3 .pass-strength__label,
+  .pass-strength.level-4 .pass-strength__label{color:var(--text)}
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add a password strength indicator element to the auth view
- compute password strength from password characteristics and update the indicator on input
- style the indicator with animated bar and color scale feedback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2a1d99e4c832aa6f4b902c0f89ac3