### PR TITLE
Add random nickname generator to auth screen

### DIFF
--- a/zombie_http_v8_0/static/app.js
+++ b/zombie_http_v8_0/static/app.js
@@ -17,6 +17,13 @@ let PLANT_COOLDOWN_UNTIL=0;
 let USERNAME_CHECK_STATE={available:false,msg:'Введите логин',tone:'muted',pending:false};
 let USERNAME_CHECK_COUNTER=0;
 
+const NICKNAME_ADJECTIVES=[
+  'Swift','Brave','Lucky','Frosty','Cosmic','Mighty','Sunny','Shadow','Electric','Silent'
+];
+const NICKNAME_NOUNS=[
+  'Pea','Runner','Knight','Guardian','Sprout','Ranger','Sun','Dream','Zombie','Bolt'
+];
+
 const DEFAULT_OWNED = ['peashooter','sunflower','wallnut'];
 const DEFAULT_ZOMBIE_CLASSES = ['normal','cone','bucket'];
 const DEFAULT_ZOMBIE_DECK = DEFAULT_ZOMBIE_CLASSES.slice();
@@ -451,6 +458,25 @@ function scheduleUsernameCheck(raw){
   debouncedUsernameCheck(value, counter);
 }
 
+function generateNickname(){
+  const loginInput=document.getElementById('login');
+  if(!loginInput){
+    return '';
+  }
+  const adj=NICKNAME_ADJECTIVES[Math.floor(Math.random()*NICKNAME_ADJECTIVES.length)]||'Swift';
+  const noun=NICKNAME_NOUNS[Math.floor(Math.random()*NICKNAME_NOUNS.length)]||'Pea';
+  const number=Math.floor(Math.random()*900)+100;
+  const nickname=`${adj}${noun}${number}`;
+  loginInput.value=nickname;
+  loginInput.dispatchEvent(new Event('input',{bubbles:true}));
+  loginInput.focus();
+  if(typeof loginInput.setSelectionRange==='function'){
+    const len=nickname.length;
+    loginInput.setSelectionRange(len, len);
+  }
+  return nickname;
+}
+
 function updateAuthStatusUI(){
   const status=document.getElementById('loginStatus');
   if(status){
@@ -523,7 +549,7 @@ function initAuthControls(){
 
 function renderAuth(){
   left.innerHTML = `<h2>Вход / Регистрация</h2>
-  <div class="row"><input id="login" placeholder="Логин (латиница/цифры ._-)" /></div>
+  <div class="row login-row"><input id="login" placeholder="Логин (латиница/цифры ._-)" /><button type="button" class="btn" onclick="generateNickname()"><span>🎲</span> Рандомный ник</button></div>
   <div class="muted" id="loginStatus"></div>
   <div class="row"><input id="pass" type="password" placeholder="Пароль (мин. 4 символа)" /></div>
   <div id="passStrength" class="pass-strength level-0 is-empty">

--- a/zombie_http_v8_0/static/index.html
+++ b/zombie_http_v8_0/static/index.html
@@ -25,6 +25,13 @@
   .btn:disabled{opacity:.55;cursor:not-allowed}
   .muted{color:var(--muted);font-size:12px}
   .row{margin:8px 0}
+  .login-row{display:flex;gap:8px;align-items:center}
+  .login-row input{flex:1}
+  .login-row .btn{margin:0;white-space:nowrap}
+  @media (max-width:520px){
+    .login-row{flex-direction:column;align-items:stretch}
+    .login-row .btn{width:100%;justify-content:center;margin-top:8px}
+  }
   input,select,button{font-family:'Inter',system-ui,Arial}
   input,select{width:100%;padding:10px;border:1px solid var(--btnb);border-radius:10px;box-sizing:border-box}
   h2{margin:8px 0}


### PR DESCRIPTION
## Summary
- add a "Рандомный ник" button next to the login field and implement the generator logic
- update auth form layout styles so the new button aligns with existing controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2a3f8c460832a9d87b6531d15422a