### PR TITLE
Revamp authentication screen layout

### DIFF
--- a/zombie_http_v8_0/static/app.js
+++ b/zombie_http_v8_0/static/app.js
@@ -416,6 +416,7 @@ function startCountdownTicker(){
 function stopCountdownTicker(){ if(COUNTDOWN_TIMER){ clearInterval(COUNTDOWN_TIMER); COUNTDOWN_TIMER=null; const cd=document.getElementById('countdown'); if(cd) cd.textContent=''; } }
 
 function render(){
+  document.body.classList.toggle('auth-view', VIEW==='auth');
   if(USER){
     navbar.innerHTML = `<span style="cursor:pointer" onclick="openProfile('${USER}')"><img class="avatar" src="${avatarUrl(USER)}&s=24" style="width:24px;height:24px"/> <b>${USER}</b></span>`;
   }else{ navbar.textContent = 'Гость'; }
@@ -548,18 +549,47 @@ function initAuthControls(){
 }
 
 function renderAuth(){
-  left.innerHTML = `<h2>Вход / Регистрация</h2>
-  <div class="row login-row"><input id="login" placeholder="Логин (латиница/цифры ._-)" /><button type="button" class="btn" onclick="generateNickname()"><span>🎲</span> Рандомный ник</button></div>
-  <div class="muted" id="loginStatus"></div>
-  <div class="row"><input id="pass" type="password" placeholder="Пароль (мин. 4 символа)" /></div>
-  <div id="passStrength" class="pass-strength level-0 is-empty">
-    <div class="pass-strength__track"><div class="pass-strength__bar"></div></div>
-    <div class="pass-strength__label muted">Введите пароль</div>
-  </div>
-  <div class="row"><button id="registerBtn" class="btn" onclick="register()"><span>📝</span> Регистрация</button>
-  <button class="btn primary" onclick="signin()"><span>🔑</span> Вход</button></div>
-  <div class="muted" id="authMsg"></div>`;
-  main.innerHTML = `<div class='muted'>Это страница входа. После входа попадёшь на главную.</div>`;
+  left.innerHTML = `
+    <div class="auth-card">
+      <div class="auth-card__header">
+        <h1>Zombie Coop</h1>
+        <p class="auth-card__subtitle">Кооперативные битвы растений и зомби</p>
+      </div>
+      <p class="auth-card__hint">Создай логин и пароль, чтобы собраться с друзьями и защитить двор от волн зомби.</p>
+      <div class="auth-card__indicators">
+        <div class="auth-card__status muted" id="loginStatus"></div>
+      </div>
+      <label class="auth-card__label" for="login">Логин</label>
+      <div class="row login-row">
+        <input id="login" placeholder="Логин (латиница/цифры ._-)" />
+        <button type="button" class="btn" onclick="generateNickname()"><span>🎲</span> Рандомный ник</button>
+      </div>
+      <label class="auth-card__label" for="pass">Пароль</label>
+      <div class="row">
+        <input id="pass" type="password" placeholder="Пароль (мин. 4 символа)" />
+      </div>
+      <div id="passStrength" class="pass-strength level-0 is-empty">
+        <div class="pass-strength__track"><div class="pass-strength__bar"></div></div>
+        <div class="pass-strength__label muted">Введите пароль</div>
+      </div>
+      <div class="row auth-card__actions">
+        <button id="registerBtn" class="btn" onclick="register()"><span>📝</span> Регистрация</button>
+        <button class="btn primary" onclick="signin()"><span>🔑</span> Вход</button>
+      </div>
+      <div class="auth-card__helper muted">Регистрация сохраняет прогресс и коллекцию карточек.</div>
+      <div class="muted" id="authMsg"></div>
+    </div>`;
+  main.innerHTML = `
+    <div class="auth-illustration">
+      <div class="auth-illustration__badge">🧟‍♂️</div>
+      <h2>Стань защитником сада</h2>
+      <p>Присоединяйся к кооперативным матчам, делись стратегией и отбивай волны зомби вместе с товарищами.</p>
+      <ul class="auth-illustration__list">
+        <li>Создавай лобби и приглашай друзей</li>
+        <li>Развивай коллекцию растений и зомби</li>
+        <li>Соревнуйся за место в таблице лидеров</li>
+      </ul>
+    </div>`;
   initAuthControls();
 }
 async function register(){

--- a/zombie_http_v8_0/static/index.html
+++ b/zombie_http_v8_0/static/index.html
@@ -16,9 +16,9 @@
     --good:#16a34a; --bad:#ef4444; --accent:#60a5fa;
   }
   *{box-sizing:border-box} body{font-family:'Inter',system-ui,Arial;background:var(--bg);margin:0;color:var(--text)}
-  header{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:#ffffff;border-bottom:1px solid var(--border)}
-  .wrap{display:flex;min-height:calc(100vh - 56px)}
-  aside{width:360px;background:var(--panel);border-right:1px solid var(--border);padding:16px;overflow:auto}
+  header{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:#ffffff;border-bottom:1px solid var(--border);transition:background .3s ease,color .3s ease}
+  .wrap{display:flex;min-height:calc(100vh - 56px);transition:padding .3s ease}
+  aside{width:360px;background:var(--panel);border-right:1px solid var(--border);padding:16px;overflow:auto;transition:background .3s ease,border-color .3s ease,box-shadow .3s ease}
   main{flex:1;display:flex;align-items:center;justify-content:center;padding:12px}
   .btn{display:inline-flex;align-items:center;gap:6px;padding:10px 14px;margin:4px 0;border:1px solid var(--btnb);border-radius:10px;background:var(--btn);cursor:pointer}
   .btn.primary{background:var(--primary);color:#fff;border-color:var(--primaryb)}
@@ -28,9 +28,40 @@
   .login-row{display:flex;gap:8px;align-items:center}
   .login-row input{flex:1}
   .login-row .btn{margin:0;white-space:nowrap}
+  .auth-card{background:rgba(255,255,255,0.95);border-radius:24px;padding:32px 28px;box-shadow:0 24px 60px rgba(15,23,42,0.25);display:flex;flex-direction:column;gap:16px;border:1px solid rgba(255,255,255,0.45);backdrop-filter:blur(10px)}
+  .auth-card__header h1{margin:0;font-size:28px;line-height:1.2}
+  .auth-card__subtitle{margin:4px 0 0;font-size:16px;color:var(--muted)}
+  .auth-card__hint{margin:0;color:var(--muted);line-height:1.5}
+  .auth-card__label{font-weight:600;font-size:14px;margin-top:4px}
+  .auth-card__indicators{min-height:18px}
+  .auth-card__status{font-size:12px}
+  .auth-card__actions{display:flex;gap:8px;flex-wrap:wrap}
+  .auth-card__helper{font-size:12px;line-height:1.4}
+  .auth-illustration{background:rgba(15,23,42,0.35);border-radius:28px;padding:32px;display:flex;flex-direction:column;gap:12px;box-shadow:0 30px 80px rgba(8,47,73,0.45);backdrop-filter:blur(6px);max-width:420px}
+  .auth-illustration h2{margin:0;font-size:26px;line-height:1.25}
+  .auth-illustration__badge{width:64px;height:64px;border-radius:20px;background:rgba(34,197,94,0.25);display:flex;align-items:center;justify-content:center;font-size:32px;color:#bbf7d0}
+  .auth-illustration__list{margin:0;padding-left:20px;display:flex;flex-direction:column;gap:6px;font-size:14px;color:rgba(226,232,240,0.85)}
+  body.auth-view{background:radial-gradient(1200px at 10% 10%,rgba(34,197,94,0.22),transparent 55%),radial-gradient(900px at 90% 20%,rgba(59,130,246,0.18),transparent 60%),linear-gradient(135deg,#0f172a 0%,#1f2937 45%,#0b1120 100%);color:#e2e8f0}
+  body.auth-view header{background:rgba(15,23,42,0.2);border-bottom:1px solid rgba(226,232,240,0.2);color:#f8fafc}
+  body.auth-view header .muted{color:rgba(226,232,240,0.75)}
+  body.auth-view .wrap{justify-content:center;align-items:center;padding:48px 32px;gap:48px}
+  body.auth-view aside{width:min(420px,100%);background:transparent;border-right:none;padding:0;overflow:visible;box-shadow:none}
+  body.auth-view main{flex:0 1 420px;padding:0;color:#f8fafc}
+  body.auth-view main:empty{display:none}
+  body.auth-view main .auth-illustration{color:#f8fafc}
+  body.auth-view aside .muted{color:#64748b}
+  body.auth-view .auth-card__status{color:var(--muted)}
   @media (max-width:520px){
     .login-row{flex-direction:column;align-items:stretch}
     .login-row .btn{width:100%;justify-content:center;margin-top:8px}
+    .auth-card{padding:28px 22px;border-radius:20px}
+    .auth-card__actions{flex-direction:column}
+    .auth-card__actions .btn{width:100%;justify-content:center}
+  }
+  @media (max-width:768px){
+    body.auth-view .wrap{flex-direction:column;padding:32px 16px 48px;gap:32px}
+    body.auth-view main{display:none}
+    body.auth-view header{background:rgba(15,23,42,0.35)}
   }
   input,select,button{font-family:'Inter',system-ui,Arial}
   input,select{width:100%;padding:10px;border:1px solid var(--btnb);border-radius:10px;box-sizing:border-box}


### PR DESCRIPTION
## Summary
- restructure the authentication render to use a dedicated card with headers, helper copy, and an illustration panel
- refresh the auth view styling with a gradient background, shadowed card, and responsive tweaks for mobile spacing

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2a56f1b2c832a9485460388b4743e