### PR TITLE
Adjust zombie placement threshold

### DIFF
--- a/zombie_http_v8_0/static/app.js
+++ b/zombie_http_v8_0/static/app.js
@@ -1102,7 +1102,7 @@ function canPlace(r,c){
   if(!GAME_STATE) return false;
   if(GAME_STATE.grid[r][c]) return false;
   const cellRight=(c+1)*80;
-  const threshold=cellRight - 0.4*80;
+  const threshold=cellRight - 0.3*80;
   if(Array.isArray(GAME_STATE.zombies)){
     for(const z of GAME_STATE.zombies){
       if(!z || z.row!==r) continue;


### PR DESCRIPTION
## Summary
- lower the zombie proximity threshold used by `canPlace` to 30% of a cell width so planting is blocked once a zombie occupies most of the tile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2dc09cf94832a9f2764b240274c22