### PR TITLE
Increase zombie placement block threshold to 70%

### DIFF
--- a/zombie_http_v8_0/app.py
+++ b/zombie_http_v8_0/app.py
@@ -1171,7 +1171,7 @@ def on_place_plant(data):
         if r not in allowed: emit("action_result", {"status":"error","msg":"Не ваша зона"}); return
         if st["grid"][r][c] is not None: emit("action_result", {"status":"error","msg":"Занято"}); return
         cell_right = (c + 1) * CELL_SIZE
-        block_threshold = cell_right - 0.4 * CELL_SIZE
+        block_threshold = cell_right - 0.7 * CELL_SIZE
         for z in st.get("zombies", []):
             if z.get("row") != r:
                 continue


### PR DESCRIPTION
## Summary
- update the server-side placement check to block planting when a zombie has advanced beyond 70% of a cell

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2e463e438832a9cdcdfeb19eddf97