### PR TITLE
Add craft modal support and update navbar actions

### DIFF
--- a/zombie_http_v8_0/static/app.js
+++ b/zombie_http_v8_0/static/app.js
@@ -87,6 +87,7 @@ const navbar = document.getElementById('navbar');
 const modal = document.getElementById('createModal');
 const profileModal = document.getElementById('profileModal');
 const shopModal = document.getElementById('shopModal');
+const craftModal = document.getElementById('craftModal');
 
 function debounce(fn, delay=300){
   let timer;
@@ -416,6 +417,18 @@ function buyItem(item){
 }
 function closeShop(){ shopModal.style.display='none'; }
 
+function openCraft(){
+  if(craftModal){
+    craftModal.style.display='flex';
+  }
+}
+
+function closeCraft(){
+  if(craftModal){
+    craftModal.style.display='none';
+  }
+}
+
 function logout(){ localStorage.removeItem('USER'); USER=null; closeProfile(); setView('auth'); }
 
 socket.on('connected', ()=>{
@@ -566,8 +579,17 @@ function stopCountdownTicker(){ if(COUNTDOWN_TIMER){ clearInterval(COUNTDOWN_TIM
 function render(){
   document.body.classList.toggle('auth-view', VIEW==='auth');
   if(USER){
-    navbar.innerHTML = `<span style="cursor:pointer" onclick="openProfile('${USER}')"><img class="avatar" src="${avatarUrl(USER)}&s=24" style="width:24px;height:24px"/> <b>${USER}</b></span>`;
-  }else{ navbar.textContent = 'Гость'; }
+    navbar.classList.remove('muted');
+    const profileHtml = `<span style="cursor:pointer" onclick="openProfile('${USER}')"><img class="avatar" src="${avatarUrl(USER)}&s=24" style="width:24px;height:24px"/> <b>${USER}</b></span>`;
+    navbar.innerHTML = `
+      <button class="btn" onclick="openCraft()"><span>🧪</span> Крафт</button>
+      <button class="btn" onclick="openShop()"><span>🛒</span> Магазин</button>
+      ${profileHtml}
+    `;
+  }else{
+    navbar.classList.add('muted');
+    navbar.textContent = 'Гость';
+  }
   if(VIEW==='auth'){ renderAuth(); return; }
   if(VIEW==='home'){ renderHome(); return; }
   if(VIEW==='room'){ renderRoom(); return; }

--- a/zombie_http_v8_0/static/index.html
+++ b/zombie_http_v8_0/static/index.html
@@ -142,10 +142,9 @@
 <div class="modal" id="profileModal">
   <div class="box">
     <div id="profileBox">Загрузка...</div>
-    <div style="display:flex;justify-content:space-between;align-items:center;margin-top:8px">
-      <div><button class="btn" onclick="openShop()"><span>🛒</span> Магазин</button></div>
-      <div><button class="btn" onclick="logout()"><span>🚪</span> Выйти</button>
-      <button class="btn" onclick="closeProfile()">Закрыть</button></div>
+    <div style="display:flex;justify-content:flex-end;align-items:center;margin-top:8px;gap:8px">
+      <button class="btn" onclick="logout()"><span>🚪</span> Выйти</button>
+      <button class="btn" onclick="closeProfile()">Закрыть</button>
     </div>
   </div>
 </div>
@@ -155,6 +154,14 @@
     <h3>Магазин</h3>
     <div id="shopBox" class="muted">Загрузка...</div>
     <div style="text-align:right;margin-top:8px"><button class="btn" onclick="closeShop()">Закрыть</button></div>
+  </div>
+</div>
+
+<div class="modal" id="craftModal">
+  <div class="box">
+    <h3>Крафт</h3>
+    <div id="craftBox" class="muted">Здесь пока пусто...</div>
+    <div style="text-align:right;margin-top:8px"><button class="btn" onclick="closeCraft()">Закрыть</button></div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- add craft modal wiring and expose openCraft/closeCraft handlers alongside the shop logic
- render active Craft and Shop buttons in the navbar ahead of the user avatar information
- restructure profile modal footer and add the craft modal markup so the new handlers have a target container

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2ebebd960832a966f600e725fb390