### PR TITLE
Lower zombie planting block threshold to 20%

### DIFF
--- a/zombie_http_v8_0/app.py
+++ b/zombie_http_v8_0/app.py
@@ -1171,7 +1171,7 @@ def on_place_plant(data):
         if r not in allowed: emit("action_result", {"status":"error","msg":"Не ваша зона"}); return
         if st["grid"][r][c] is not None: emit("action_result", {"status":"error","msg":"Занято"}); return
         cell_right = (c + 1) * CELL_SIZE
-        block_threshold = cell_right - 0.4 * CELL_SIZE
+        block_threshold = cell_right - 0.2 * CELL_SIZE
         for z in st.get("zombies", []):
             if z.get("row") != r:
                 continue


### PR DESCRIPTION
## Summary
- adjust the plant placement block to trigger when a zombie has moved beyond 20% of the cell width

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2e463e438832a9cdcdfeb19eddf97