### PR TITLE
Adjust home layout responsiveness

### DIFF
--- a/zombie_http_v8_0/static/app.js
+++ b/zombie_http_v8_0/static/app.js
@@ -813,7 +813,7 @@ function renderHome(){
     <div class="row"><button class="btn primary" onclick="openModal()"><span>➕</span> Создать игру</button></div>
     <div class="row"><button class="btn" onclick="showLeaderboard()"><span>🏆</span> Топ игроков</button></div>
     <div id="leaders" class="muted"></div>`;
-  main.innerHTML = `<div style="width:920px">
+  main.innerHTML = `<div class="main-home">
     <h3>Список комнат</h3>
     <div id="rooms" class="rooms-container"><div class="rooms-loading">Загрузка…</div></div>
   </div>`;

--- a/zombie_http_v8_0/static/index.html
+++ b/zombie_http_v8_0/static/index.html
@@ -19,7 +19,7 @@
   header{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:#ffffff;border-bottom:1px solid var(--border);transition:background .3s ease,color .3s ease}
   .wrap{display:flex;min-height:calc(100vh - 56px);transition:padding .3s ease}
   aside{width:360px;background:var(--panel);border-right:1px solid var(--border);padding:16px;overflow:auto;transition:background .3s ease,border-color .3s ease,box-shadow .3s ease}
-  main{flex:1;display:flex;align-items:center;justify-content:center;padding:12px}
+  main{flex:1;display:flex;align-items:flex-start;justify-content:center;padding:24px 16px}
   .btn{display:inline-flex;align-items:center;gap:6px;padding:10px 14px;margin:4px 0;border:1px solid var(--btnb);border-radius:10px;background:var(--btn);cursor:pointer}
   .btn.primary{background:var(--primary);color:#fff;border-color:var(--primaryb)}
   .btn:disabled{opacity:.55;cursor:not-allowed}
@@ -28,6 +28,8 @@
   .login-row{display:flex;gap:8px;align-items:center}
   .login-row input{flex:1}
   .login-row .btn{margin:0;white-space:nowrap}
+  .main-home{width:100%;max-width:clamp(320px,92vw,920px);display:flex;flex-direction:column;gap:12px}
+  .main-home h3{margin:0}
   .auth-card{background:rgba(255,255,255,0.95);border-radius:24px;padding:32px 28px;box-shadow:0 24px 60px rgba(15,23,42,0.25);display:flex;flex-direction:column;gap:16px;border:1px solid rgba(255,255,255,0.45);backdrop-filter:blur(10px)}
   .auth-card__header h1{margin:0;font-size:28px;line-height:1.2}
   .auth-card__subtitle{margin:4px 0 0;font-size:16px;color:var(--muted)}
@@ -70,8 +72,9 @@
   .sep{height:1px;background:var(--border);margin:12px 0}
   .pill{display:inline-flex;align-items:center;gap:6px;padding:4px 8px;border-radius:999px;border:1px solid var(--border);background:#f8fafc;margin:2px; cursor:pointer}
   .ready{color:var(--good)} .notready{color:var(--bad)}
-  .room{border:1px solid var(--border);border-radius:12px;padding:8px;margin:8px 0;background:#f8fff8}
-  .rooms-container{display:flex;flex-direction:column;gap:12px;min-height:120px}
+  .room{border:1px solid var(--border);border-radius:12px;padding:8px;margin:8px 0;background:#f8fff8;width:100%}
+  .room .btn{width:100%;justify-content:center}
+  .rooms-container{display:flex;flex-direction:column;gap:12px;min-height:120px;width:100%}
   .rooms-loading{padding:32px 0;text-align:center;color:var(--muted);font-size:14px}
   .empty-state{border:1px dashed var(--border);border-radius:16px;padding:32px 24px;background:#ffffff;display:flex;flex-direction:column;align-items:center;gap:12px;text-align:center;color:var(--muted)}
   .empty-state__icon{font-size:36px;line-height:1}
@@ -107,6 +110,16 @@
   .profile-item-icon{font-size:20px;width:32px;height:32px;display:flex;align-items:center;justify-content:center;background:#fff;border-radius:10px}
   .profile-item-title{font-weight:600;font-size:14px}
   .profile-item-sub{font-size:12px;color:var(--muted);margin-top:2px}
+  @media (max-width:960px){
+    body:not(.auth-view) aside{width:280px}
+    body:not(.auth-view) .main-home{max-width:clamp(320px,96vw,860px)}
+  }
+  @media (max-width:720px){
+    body:not(.auth-view) .wrap{flex-direction:column}
+    body:not(.auth-view) aside{width:100%;border-right:none;border-bottom:1px solid var(--border)}
+    body:not(.auth-view) main{width:100%;padding:20px 16px;justify-content:flex-start}
+    body:not(.auth-view) .main-home{max-width:100%}
+  }
   @media (max-width:480px){
     .profile-inventory-list{grid-template-columns:repeat(auto-fill,minmax(130px,1fr))}
   }


### PR DESCRIPTION
## Summary
- replace the inline width in the home view with a semantic container class
- add responsive layout styles that clamp the home content width and adapt the sidebar/main stack on smaller screens
- ensure room cards and action buttons stretch to full width without horizontal scrolling

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68e39606ac50832aa2c1cce8051ac550