### PR TITLE
Improve room roster UI

### DIFF
--- a/zombie_http_v8_0/static/app.js
+++ b/zombie_http_v8_0/static/app.js
@@ -1028,20 +1028,35 @@ function drawRoomInfo(r){
   const info=document.getElementById('roomInfo');
   if(info) info.innerHTML = `Комната: <b>${r.name}</b> (ID: ${r.room_id}) <span class="badge">Режим: ${r.mode}</span> <span class="badge">Игроков: ${r.players.length}/${r.max_players}</span> · Хост: <span class="pill" onclick="openProfile('${r.owner}')">${r.owner}</span>`;
   const playersDiv=document.getElementById('players');
+  let readyCount=0;
   if(playersDiv){
     const roles=r.roles||{}; const assigned=r.assigned||{};
+    readyCount = r.players.filter(p=>p.ready).length;
     if(!r.players.length){
-      playersDiv.innerHTML = `<div class="room-roster__empty">Пока пусто</div>`;
+      playersDiv.innerHTML = `<div class="room-roster__summary">Готовы: 0/0</div><div class="room-roster__empty">Пока пусто</div>`;
     } else {
-      playersDiv.innerHTML = r.players.map(p=>{
+      const cards = r.players.map(p=>{
         const choice=roles[p.name]||'random';
         const final=(assigned && assigned.defender===p.name)?'plant':(assigned && assigned.attacker===p.name)?'zombie':choice;
-        const badge = r.mode==='pvp'?` <span class="muted">(${roleIcon(final)})</span>`:'';
-        return `<span class="pill" onclick="openProfile('${p.name}')">${p.name} ${p.ready?'✔️':'❌'}${badge}</span>`;
-      }).join(' ');
+        const isReady = !!p.ready;
+        const isHost = p.name===r.owner;
+        const roleMarkup = `${roleIcon(final)} ${roleLabel(final)}`;
+        return `<div class="player-tile${isReady?' player-tile--ready':''}${isHost?' player-tile--host':''}" onclick="openProfile('${p.name}')">
+          <img class="player-tile__avatar" src="${avatarUrl(p.name)}" alt="${p.name}" />
+          <div class="player-tile__info">
+            <div class="player-tile__name">${p.name}</div>
+            <div class="player-tile__role">${roleMarkup}</div>
+          </div>
+          <div class="player-tile__badges">
+            ${isHost?'<span class="player-tile__badge player-tile__badge--host">Хост</span>':''}
+            <span class="player-tile__badge ${isReady?'player-tile__badge--ready':'player-tile__badge--waiting'}">${isReady?'Готов':'Ждёт'}</span>
+          </div>
+        </div>`;
+      });
+      playersDiv.innerHTML = `<div class="room-roster__summary">Готовы: ${readyCount}/${r.players.length}</div>` + cards.join('');
     }
   }
-  const startBtn=document.getElementById('startBtn'); if(startBtn){ const allReady = (r.players.length===r.max_players) && r.players.every(p=>p.ready); startBtn.disabled = !(USER===r.owner && allReady); }
+  const startBtn=document.getElementById('startBtn'); if(startBtn){ const totalPlayers=r.players.length; const maxPlayers=r.max_players; const allReady=(totalPlayers===maxPlayers) && readyCount===totalPlayers; startBtn.disabled = !(USER===r.owner && allReady); }
   MY_INDEX = Math.max(0, r.players.map(p=>p.name).indexOf(USER));
   if(r.mode==='pvp' && r.assigned){
     if(r.assigned.defender===USER) MY_INDEX=0;
@@ -1092,6 +1107,13 @@ function roleIcon(code){
   if(code==='plant') return '🌿';
   if(code==='zombie') return '🧟';
   return '🎲';
+}
+
+function roleLabel(code){
+  if(code==='plant') return 'Растения';
+  if(code==='zombie') return 'Зомби';
+  if(code==='random') return 'Случайно';
+  return '—';
 }
 
 function buildRoleControls(r){

--- a/zombie_http_v8_0/static/index.html
+++ b/zombie_http_v8_0/static/index.html
@@ -85,9 +85,23 @@
   .room-info__feedback{font-size:12px;color:var(--muted);min-height:16px;opacity:0;transition:opacity .25s ease}
   .room-info__feedback.is-visible{opacity:1}
   .room-roster{border:1px solid var(--border);border-radius:14px;background:#ffffff;min-height:140px;display:flex;flex-direction:column}
-  .room-roster__list{flex:1;overflow-y:auto;padding:12px;display:flex;flex-wrap:wrap;gap:8px;align-content:flex-start}
-  .room-roster__list .pill{margin:0}
-  .room-roster__empty{padding:12px;color:var(--muted)}
+  .room-roster__list{flex:1;overflow-y:auto;padding:12px;display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:10px;align-content:flex-start}
+  .room-roster__summary{grid-column:1/-1;font-size:12px;color:var(--muted);display:flex;justify-content:flex-end;align-items:center;padding:0 2px 4px}
+  .player-tile{display:flex;align-items:center;gap:12px;padding:10px;border-radius:12px;border:1px solid var(--border);background:#f8fafc;transition:transform .15s ease,box-shadow .15s ease;cursor:pointer}
+  .player-tile:hover{transform:translateY(-2px);box-shadow:0 8px 18px rgba(15,23,42,0.08)}
+  .player-tile--ready{border-color:rgba(34,197,94,0.4);background:rgba(34,197,94,0.12)}
+  .player-tile--host{box-shadow:0 0 0 2px rgba(96,165,250,0.35)}
+  .player-tile__avatar{width:42px;height:42px;border-radius:14px;object-fit:cover;border:2px solid rgba(148,163,184,0.4)}
+  .player-tile--ready .player-tile__avatar{border-color:rgba(34,197,94,0.45)}
+  .player-tile__info{flex:1;min-width:0;display:flex;flex-direction:column;gap:4px}
+  .player-tile__name{font-weight:600;font-size:14px;color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .player-tile__role{font-size:12px;color:var(--muted);display:flex;align-items:center;gap:6px}
+  .player-tile__badges{display:flex;flex-direction:column;gap:6px;align-items:flex-end}
+  .player-tile__badge{font-size:11px;padding:2px 8px;border-radius:999px;border:1px solid var(--border);background:#fff;display:inline-flex;align-items:center;gap:4px;white-space:nowrap}
+  .player-tile__badge--ready{border-color:rgba(34,197,94,0.5);background:rgba(34,197,94,0.15);color:var(--good)}
+  .player-tile__badge--waiting{border-color:rgba(239,68,68,0.45);background:rgba(254,226,226,0.45);color:var(--bad)}
+  .player-tile__badge--host{border-color:rgba(96,165,250,0.45);background:rgba(219,234,254,0.7);color:#1d4ed8;font-weight:600}
+  .room-roster__empty{padding:12px;color:var(--muted);grid-column:1/-1}
   .room-roster__countdown{min-height:18px}
   .room-chat__log{border:1px solid var(--border);border-radius:14px;background:#ffffff;padding:12px;height:360px;overflow:auto}
   .room-chat__form{display:flex;gap:8px;align-items:center}


### PR DESCRIPTION
## Summary
- replace the room roster pills with avatar-based player tiles and add a ready counter
- add styling for the new roster layout, host badge, and readiness states
- update the start button enablement to rely on the shared ready counter value

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4190b734c832a8637959dfe3c01c3