### PR TITLE
Improve room chat handling

### DIFF
--- a/zombie_http_v8_0/static/index.html
+++ b/zombie_http_v8_0/static/index.html
@@ -106,6 +106,12 @@
   .room-chat__log{border:1px solid var(--border);border-radius:14px;background:#ffffff;padding:12px;height:360px;overflow:auto}
   .room-chat__form{display:flex;gap:8px;align-items:center}
   .room-chat__form input{flex:1}
+  .chat-message{font-size:13px;line-height:1.35;margin-bottom:6px;display:flex;align-items:flex-start;gap:6px}
+  .chat-message:last-child{margin-bottom:0}
+  .chat-message__time{font-size:11px;color:var(--muted);flex-shrink:0;min-width:42px}
+  .chat-message__author{font-weight:600}
+  .chat-message__text{white-space:pre-wrap;word-break:break-word}
+  .chat-message--system .chat-message__author,.chat-message--system .chat-message__text{color:var(--muted)}
   .room-actions{display:flex;flex-wrap:wrap;gap:8px;margin:12px 0}
   .room-actions:empty{display:none;margin:0}
   .room-actions--single{justify-content:flex-start}


### PR DESCRIPTION
## Summary
- add frontend helpers to render room chat history with timestamps and shared formatting
- refresh the room chat log from room updates and allow pressing Enter to send non-empty messages
- centralize backend chat handling to append timestamps for system and player messages

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68e41cd9da24832a9f7867ffdccf354b