### PR TITLE
Reduce resource drop rates

### DIFF
--- a/zombie_http_v8_0/app.py
+++ b/zombie_http_v8_0/app.py
@@ -36,7 +36,9 @@ DEFAULT_PLANT_OWNED = ["peashooter","sunflower","wallnut"]
 DEFAULT_ZOMBIE_CLASSES = ["normal", "cone", "bucket"]
 DEFAULT_ZOMBIE_DECK = DEFAULT_ZOMBIE_CLASSES[:]
 
-RESOURCE_DROP_CHANCE = 0.20
+# Lowered the base drop chance so that all resource drops are rarer for both
+# plants and zombies.
+RESOURCE_DROP_CHANCE = 0.10
 
 PLANT_RESOURCE_DROPS = {
     "sunflower": {"item": "sun_crystal", "name": "Солнечные кристаллы", "icon": "🌞"},


### PR DESCRIPTION
## Summary
- lower the global resource drop chance so plant and zombie drops are rarer

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68e56b4a11e8832ab45a17ab6dd9ac21