### PR TITLE
Add sell confirmation for planted items

### DIFF
--- a/zombie_http_v8_0/static/app.js
+++ b/zombie_http_v8_0/static/app.js
@@ -1294,6 +1294,9 @@ function renderDefenderGame(isPvP){
     if(cellData){
       const plantType=cellData?.type;
       if(!plantType){ setStatus('Нельзя продать неизвестное растение'); return; }
+      const plantName = PLANT_META_MAP[plantType]?.name || 'растение';
+      const confirmText = `Продать ${plantName}?`;
+      if(!window.confirm(confirmText)){ setStatus('Продажа отменена'); return; }
       PENDING_ACTIONS.push({type:'sell', row:r, col:c, ptype:plantType});
       socket.emit('sell_plant',{room_id:ROOM_ID,username:USER,row:r,col:c,ptype:plantType});
       return;


### PR DESCRIPTION
## Summary
- prompt players to confirm before selling a planted unit
- prevent accidental sales by cancelling when the confirmation is declined

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e56bb8cb90832a8e27ab629a28f2bb