### PR TITLE
Enable PvP zombie resource drops and highlight local player in summary

### DIFF
--- a/zombie_http_v8_0/app.py
+++ b/zombie_http_v8_0/app.py
@@ -187,6 +187,7 @@ def record_plant_destroyed_by_zombie(st: dict, plant_type: str):
         entry = {}
     entry[plant_type] = entry.get(plant_type, 0) + 1
     destroyed[attacker] = entry
+    maybe_award_resource_drop(st, attacker, PLANT_RESOURCE_DROPS, plant_type)
 
 
 def record_resource_gain(st: dict, owner: str, resource_code: str, amount: int = 1):

--- a/zombie_http_v8_0/static/app.js
+++ b/zombie_http_v8_0/static/app.js
@@ -1456,6 +1456,9 @@ function renderGameOverSummary(data){
         roleHint='Участник PvP';
       }
     }
+    const isSelf = typeof USER==='string' && USER && name===USER;
+    const cardClasses=['summary-card'];
+    if(isSelf){ cardClasses.push('summary-card--self'); }
     let plantsHtml='<span class="muted">—</span>';
     if(plantMap && typeof plantMap==='object'){
       const entries=Object.entries(plantMap).filter(([,cnt])=>safeStatNumber(cnt)>0);
@@ -1517,7 +1520,7 @@ function renderGameOverSummary(data){
         }).join(' ');
       }
     }
-    return `<div class="summary-card" style="border:1px solid var(--border);border-radius:18px;padding:18px;background:#fff;display:flex;flex-direction:column;gap:14px;box-shadow:0 18px 36px rgba(15,23,42,0.08)">
+    return `<div class="${cardClasses.join(' ')}">
       <div style="display:flex;align-items:center;gap:12px">
         <img class="avatar" src="${avatarUrl(name)}&s=48" alt="${name}" style="width:48px;height:48px"/>
         <div>

--- a/zombie_http_v8_0/static/index.html
+++ b/zombie_http_v8_0/static/index.html
@@ -145,6 +145,8 @@
   .card.selected{outline:2px solid var(--accent)}
   .icon{width:28px;height:28px;display:inline-flex;align-items:center;justify-content:center;font-size:18px}
   .badge{font-size:12px;padding:2px 6px;border-radius:8px;border:1px solid var(--border);background:#fff}
+  .summary-card{border:1px solid var(--border);border-radius:18px;padding:18px;background:#fff;display:flex;flex-direction:column;gap:14px;box-shadow:0 18px 36px rgba(15,23,42,0.08);transition:transform .2s ease,box-shadow .2s ease,border-color .2s ease}
+  .summary-card--self{border-color:var(--accent);box-shadow:0 0 0 3px rgba(96,165,250,0.35),0 22px 44px rgba(30,64,175,0.2);transform:translateY(-2px)}
   .modal{position:fixed;inset:0;background:rgba(0,0,0,.35);display:none;align-items:center;justify-content:center;padding:16px}
   .modal__content{display:flex;align-items:center;justify-content:center}
   .modal > .box,


### PR DESCRIPTION
## Summary
- award PvP attackers with resource drops when they destroy plants so the gains appear in post-match stats
- add styling and logic to highlight the current player's card in the end-of-match summary

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68e575cbc400832a82f6934763f3d429